### PR TITLE
Use dn for auth

### DIFF
--- a/src/Security/Core/Authentication/Provider/LdapAuthenticationProvider.php
+++ b/src/Security/Core/Authentication/Provider/LdapAuthenticationProvider.php
@@ -53,9 +53,17 @@ class LdapAuthenticationProvider implements AuthenticationProviderInterface
      */
     public function authenticate(TokenInterface $token)
     {
-        $user = $this->userProvider->loadUserByUsername($token->getUsername());
-        if ($user && $this->ldapAuth($token->getUserName(), $token->getCredentials())) {
-            return new UsernamePasswordToken($user, null, $this->providerKey, array_unique(array_merge($this->options['roles'], $token->getRoles(), $user->getRoles())));
+        $ldapUserName = $token->getUserName();
+        $user = $this->userProvider->loadUserByUsername($ldapUserName);
+        if ($user) {
+            if( array_key_exists('useDN', $this->options) && $this->options['useDN']) {
+                if ( null==($ldapUserName = $user->getdn()) ) {
+                    throw new Exception("Attribute DN must be configured to be retreived when using useDN authentication");
+                }
+            }
+            if ($this->ldapAuth($ldapUserName, $token->getCredentials())) {
+                return new UsernamePasswordToken($user, null, $this->providerKey, array_unique(array_merge($this->options['roles'], $token->getRoles(), $user->getRoles())));
+            }
         }
 
         throw new AuthenticationException('Ldap authentication failed.');

--- a/src/Security/Core/User/LdapUserProvider.php
+++ b/src/Security/Core/User/LdapUserProvider.php
@@ -94,7 +94,7 @@ class LdapUserProvider implements UserProviderInterface
             if (array_key_exists($key, $userData) && $userData[$key]) {
                 // use first value
                 $method = 'set'.ucwords($property);
-                $user->$method($userData[$key][0]);
+                $user->$method($userData[$key]);
             }
         }
 

--- a/src/Security/Core/User/LdapUserProvider.php
+++ b/src/Security/Core/User/LdapUserProvider.php
@@ -94,7 +94,7 @@ class LdapUserProvider implements UserProviderInterface
             if (array_key_exists($key, $userData) && $userData[$key]) {
                 // use first value
                 $method = 'set'.ucwords($property);
-                $user->$method($userData[$key]);
+                $user->$method(is_array($userData[$key]) ? $userData[$key][0] : $userData[$key]);
             }
         }
 


### PR DESCRIPTION
I propose to add an option 'useDN' to ldapAuthenticationProvider, so there is no BC break.
If useDN is set to true, attribute dn has to be retrieved by ldapUserProvider.
